### PR TITLE
fix(weixin): render URL QR artifacts locally and validate on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@openai/agents": "^0.8.5",
         "ffmpeg-static": "^5.3.0",
         "ffprobe-static": "^3.1.0",
+        "qrcode": "^1.5.4",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -678,6 +679,30 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -750,11 +775,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -865,6 +928,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -874,6 +946,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -896,6 +974,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1118,6 +1202,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1161,6 +1258,15 @@
       "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1346,6 +1452,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -1383,6 +1498,18 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1527,6 +1654,42 @@
         }
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -1540,6 +1703,15 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -1573,6 +1745,15 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1594,6 +1775,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qs": {
@@ -1652,6 +1850,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1661,6 +1868,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -1762,6 +1975,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1888,6 +2107,32 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2001,6 +2246,26 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2027,6 +2292,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@openai/agents": "^0.8.5",
     "ffmpeg-static": "^5.3.0",
     "ffprobe-static": "^3.1.0",
+    "qrcode": "^1.5.4",
     "zod": "^4.3.6"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import fsp from 'node:fs/promises';
 import { spawn, type ChildProcess } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import QRCode from 'qrcode';
 import { WeixinAccountStore } from './platforms/weixin/account_store.js';
 import { WEIXIN_DEFAULT_BASE_URL, defaultCodexBridgeStateDir } from './platforms/weixin/config.js';
 import { WeixinPlatformPlugin } from './platforms/weixin/plugin.js';
@@ -337,19 +338,18 @@ async function materializeQrArtifact({ stateDir, qrcode, qrcodeImageContent }: {
   }
   if (typeof qrcodeImageContent === 'string' && /^https?:\/\//u.test(qrcodeImageContent)) {
     try {
-      const response = await fetch(qrcodeImageContent);
-      if (response.ok) {
-        const contentType = response.headers.get('content-type') ?? 'image/png';
-        const extension = mimeToExtension(contentType);
-        const filePath = path.join(outputDir, `${sanitizeFileSegment(qrcode)}.${extension}`);
-        const buffer = Buffer.from(await response.arrayBuffer());
-        await fsp.writeFile(filePath, buffer);
-        return { filePath, sourceUrl: qrcodeImageContent };
-      }
+      const filePath = path.join(outputDir, `${sanitizeFileSegment(qrcode)}.png`);
+      const buffer = await QRCode.toBuffer(qrcodeImageContent, {
+        type: 'png',
+        errorCorrectionLevel: 'M',
+        margin: 2,
+        width: 512,
+      });
+      await fsp.writeFile(filePath, buffer);
+      return { filePath, sourceUrl: qrcodeImageContent };
     } catch {
       return { filePath: null, sourceUrl: qrcodeImageContent };
     }
-    return { filePath: null, sourceUrl: qrcodeImageContent };
   }
   return { filePath: null, sourceUrl: null };
 }

--- a/test/core/bridge_coordinator.test.ts
+++ b/test/core/bridge_coordinator.test.ts
@@ -11,6 +11,10 @@ import {
 } from '../../src/core/bridge_coordinator.js';
 import { createCodexBridgeRuntime } from '../../src/runtime/bootstrap.js';
 
+function normalizeCommandSkillInput(value: unknown) {
+  return String(value ?? '').replace(/\\/g, '/');
+}
+
 class FakeProviderPlugin {
   kind: string;
   displayName: string;
@@ -2310,7 +2314,7 @@ test('/instructions skill-based drafts can be edited before confirmation and ok 
   const { runtime, openai } = makeRuntime({ codexInstructionsManager });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/instructions.md') && parserInput.includes('"subcommand": "natural"')) {
       assert.match(parserInput, /"currentInstructions"/);
       return {
@@ -2648,7 +2652,7 @@ test('/log uses model normalization and rewrites relative dates to absolute loca
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (args: any) => {
       openai.startTurnCalls.push(args);
-      if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "classify_new_record"')) {
+      if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "classify_new_record"')) {
         return {
           outputText: JSON.stringify({
             type: 'log',
@@ -2691,7 +2695,7 @@ test('/log uses model normalization and rewrites relative dates to absolute loca
     assert.match(record?.title ?? '', /停机坪的报价以及工程量的测算/);
     assert.match(record?.content ?? '', /2026-04-28 UTC/);
     assert.doesNotMatch(record?.content ?? '', /昨天/);
-    assert.ok(openai.startTurnCalls.some((call: any) => String(call.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(call.inputText ?? '').includes('"operation": "classify_new_record"')));
+    assert.ok(openai.startTurnCalls.some((call: any) => normalizeCommandSkillInput(call.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(call.inputText).includes('"operation": "classify_new_record"')));
   } finally {
     Date.now = originalDateNow;
   }
@@ -2707,7 +2711,7 @@ test('/as uses Codex classification for required same-day work instead of local 
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (args: any) => {
       openai.startTurnCalls.push(args);
-      if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "route_existing_record"')) {
+      if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "route_existing_record"')) {
         return {
           outputText: JSON.stringify({
             action: 'create',
@@ -2722,7 +2726,7 @@ test('/as uses Codex classification for required same-day work instead of local 
           title: args.bridgeSession.title,
         };
       }
-      if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "classify_new_record"')) {
+      if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "classify_new_record"')) {
         return {
           outputText: JSON.stringify({
             type: 'todo',
@@ -2766,7 +2770,7 @@ test('/as uses Codex classification for required same-day work instead of local 
     assert.doesNotMatch(record?.content ?? '', /今天必须做完/);
     assert.doesNotMatch(record?.content ?? '', /给我列出来/);
     assert.doesNotMatch(record?.content ?? '', /高的优先级/);
-    assert.ok(openai.startTurnCalls.some((call: any) => String(call.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(call.inputText ?? '').includes('"operation": "classify_new_record"')));
+    assert.ok(openai.startTurnCalls.some((call: any) => normalizeCommandSkillInput(call.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(call.inputText).includes('"operation": "classify_new_record"')));
   } finally {
     Date.now = originalDateNow;
   }
@@ -2847,7 +2851,7 @@ test('/todo edit rewrites the pending todo through the assistant record command 
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "classify_new_record"')) {
       return {
         outputText: JSON.stringify({
@@ -2934,7 +2938,7 @@ test('/todo natural language manages an existing todo through the assistant reco
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "classify_new_record"')) {
       return {
         outputText: JSON.stringify({
@@ -3093,7 +3097,7 @@ test('/as natural language updates a matching assistant record after confirmatio
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "route_existing_record"')) {
       if (input.includes('完全新的内容')) {
         return {
@@ -3239,7 +3243,7 @@ test('/as reminder wording creates a new reminder instead of merging into an unr
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "classify_new_record"')) {
+    if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "classify_new_record"')) {
       return {
         outputText: JSON.stringify({
           type: 'reminder',
@@ -3291,7 +3295,7 @@ test('/as reminder wording creates a new reminder instead of merging into an unr
   assert.equal(records[1]?.parsedJson?.normalizer, 'codex');
   assert.match(records[1]?.content ?? '', /邦杜库第四期/);
   assert.doesNotMatch(records[1]?.content ?? '', /墨盒发票/);
-  assert.ok(openai.startTurnCalls.some((call: any) => String(call.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(call.inputText ?? '').includes('"operation": "route_existing_record"')));
+  assert.ok(openai.startTurnCalls.some((call: any) => normalizeCommandSkillInput(call.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(call.inputText).includes('"operation": "route_existing_record"')));
 });
 
 test('/as edit can abandon a wrong update draft and create a new reminder', async () => {
@@ -3301,7 +3305,7 @@ test('/as edit can abandon a wrong update draft and create a new reminder', asyn
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "route_existing_record"')) {
       if (input.includes('完全新的内容')) {
         return {
@@ -3399,7 +3403,7 @@ test('/as uses Codex rewrite to merge natural-language edits into the matched as
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (args: any) => {
       openai.startTurnCalls.push(args);
-      if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "route_existing_record"')) {
+      if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "route_existing_record"')) {
         return {
           outputText: JSON.stringify({
             action: 'update',
@@ -3414,7 +3418,7 @@ test('/as uses Codex rewrite to merge natural-language edits into the matched as
           title: args.bridgeSession.title,
         };
       }
-      if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "rewrite_record"')) {
+      if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "rewrite_record"')) {
         return {
           outputText: JSON.stringify({
             action: 'update',
@@ -3476,7 +3480,7 @@ test('/as uses Codex rewrite to merge natural-language edits into the matched as
     assert.match(draftText, new RegExp(`2\\. ${expectedTomorrow} UTC`));
     assert.doesNotMatch(draftText, /明天（周二）提交给业主/);
     assert.doesNotMatch(draftText, /这个东西要记一下/);
-    assert.equal(openai.startTurnCalls.some((call: any) => String(call.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(call.inputText ?? '').includes('"operation": "rewrite_record"')), true);
+    assert.equal(openai.startTurnCalls.some((call: any) => normalizeCommandSkillInput(call.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(call.inputText).includes('"operation": "rewrite_record"')), true);
 
     const unchanged = runtime.repositories.assistantRecords.list()[0];
     assert.match(unchanged?.content ?? '', /第二张单/);
@@ -3502,7 +3506,7 @@ test('/as natural language content update preserves the matched record status', 
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "route_existing_record"')) {
       return {
         outputText: JSON.stringify({
@@ -3587,7 +3591,7 @@ test('/as ok promotes a pending target to active when confirming an update draft
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "classify_new_record"')) {
       return {
         outputText: JSON.stringify({
@@ -3683,7 +3687,7 @@ test('/note content edits that contain archive-like words do not change record s
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "classify_new_record"')) {
       return {
         outputText: JSON.stringify({
@@ -3790,7 +3794,7 @@ test('/as natural language can complete a matching assistant record after confir
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    const input = String(args.inputText ?? '');
+    const input = normalizeCommandSkillInput(args.inputText);
     if (input.includes('docs/command-skills/assistant-record.md') && input.includes('"operation": "route_existing_record"')) {
       return {
         outputText: JSON.stringify({
@@ -3851,7 +3855,7 @@ test('/as natural language can cancel a matching assistant record after confirma
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "route_existing_record"')) {
+    if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "route_existing_record"')) {
       return {
         outputText: JSON.stringify({
           action: 'cancel',
@@ -3912,7 +3916,7 @@ test('/as natural language can archive a matching assistant record after confirm
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (args: any) => {
     openai.startTurnCalls.push(args);
-    if (String(args.inputText ?? '').includes('docs/command-skills/assistant-record.md') && String(args.inputText ?? '').includes('"operation": "route_existing_record"')) {
+    if (normalizeCommandSkillInput(args.inputText).includes('docs/command-skills/assistant-record.md') && normalizeCommandSkillInput(args.inputText).includes('"operation": "route_existing_record"')) {
       return {
         outputText: JSON.stringify({
           action: 'archive',
@@ -6126,7 +6130,7 @@ test('/review custom <instructions> targets the explicit custom review path with
     text: '/review custom 只审查测试目录里的改动',
   });
 
-  assert.equal(openai.startTurnCalls.some((call: any) => String(call.inputText ?? '').includes('docs/command-skills/review.md')), false);
+  assert.equal(openai.startTurnCalls.some((call: any) => normalizeCommandSkillInput(call.inputText).includes('docs/command-skills/review.md')), false);
   assert.equal(openai.startReviewCalls.length, 1);
   assert.deepEqual(openai.startReviewCalls[0]?.target, {
     type: 'custom',
@@ -6142,7 +6146,7 @@ test('/review natural language uses the review command skill and preserves struc
   });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/review.md') && parserInput.includes('"command": "review"')) {
       assert.deepEqual(params?.event?.metadata?.codexbridge?.developerPromptContext, {
         mode: 'command-skill-parser',
@@ -6198,7 +6202,7 @@ test('/review natural language does not silently downgrade malformed skill targe
   });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/review.md') && parserInput.includes('"command": "review"')) {
       return {
         outputText: JSON.stringify({
@@ -6242,7 +6246,7 @@ test('/review custom output follows locale and stays English when locale is en',
 
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/review.md') && parserInput.includes('"command": "review"')) {
       return {
         outputText: JSON.stringify({
@@ -6276,7 +6280,7 @@ test('/review custom output follows locale and stays English when locale is en',
     focus: ['状态流转'],
   });
   assert.equal(openai.startTurnCalls.some((call: any) =>
-    String(call.inputText ?? '').includes('CodexBridge review result localizer.'),
+    normalizeCommandSkillInput(call.inputText).includes('CodexBridge review result localizer.'),
   ), false);
   assert.match(result.messages[0]?.text ?? '', /Code review \| Custom target/);
   assert.match(result.messages[0]?.text ?? '', /openai review: custom/);
@@ -6288,7 +6292,7 @@ test('/review natural language can reject execution requests and avoids starting
   });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/review.md') && parserInput.includes('"command": "review"')) {
       return {
         outputText: JSON.stringify({
@@ -6389,7 +6393,7 @@ test('/agent edit updates the pending agent draft instead of replacing it', asyn
     const { runtime, openai } = makeRuntime({ defaultCwd: '/repo' });
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         assert.match(parserInput, /"command": "agent"/);
         return {
@@ -6475,7 +6479,7 @@ test('/agent edit honors command skill reject without falling back to draft edit
     const { runtime, openai } = makeRuntime({ defaultCwd: '/repo' });
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         return {
           outputText: JSON.stringify({
@@ -6547,7 +6551,7 @@ test('/agent natural language list query uses the command skill instead of creat
     const { runtime, openai } = makeRuntime({ defaultCwd: '/repo' });
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         if (parserInput.includes('看看现在有哪些 Agent 任务')) {
           return {
@@ -6619,7 +6623,7 @@ test('/agent natural language falls back locally after one unparseable command s
     let commandSkillTurns = 0;
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         commandSkillTurns += 1;
         return {
@@ -6655,7 +6659,7 @@ test('/agent natural language proposes and confirms existing job management oper
     const { runtime, openai } = makeRuntime({ defaultCwd: '/repo' });
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         if (parserInput.includes('"userInput": "写一份项目总结"')) {
           return {
@@ -6855,7 +6859,7 @@ test('/agent natural language rejects malformed update patch enums instead of si
     const { runtime, openai } = makeRuntime({ defaultCwd: '/repo' });
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         if (parserInput.includes('"userInput": "写一份项目总结"')) {
           return {
@@ -6947,7 +6951,7 @@ test('/agent natural language can show, export, and resend existing job outputs'
     const { runtime, openai } = makeRuntime({ defaultCwd: tempDir });
     const originalStartTurn = openai.startTurn.bind(openai);
     openai.startTurn = async (params: any) => {
-      const parserInput = String(params?.inputText ?? '');
+      const parserInput = normalizeCommandSkillInput(params?.inputText);
       if (parserInput.includes('docs/command-skills/agent.md') && parserInput.includes('"subcommand": "natural"')) {
         if (parserInput.includes('"userInput": "生成报告"')) {
           return {
@@ -9354,7 +9358,7 @@ test('/auto add natural language produces a draft through provider normalization
   });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/auto.md')) {
       return {
         outputText: JSON.stringify({
@@ -9402,7 +9406,7 @@ test('/auto add natural language can create multiple daily schedules from one re
   });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/auto.md')) {
       return {
         outputText: JSON.stringify({
@@ -9459,7 +9463,7 @@ test('/auto edit updates the pending automation draft instead of replacing it', 
   });
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/auto.md') && parserInput.includes('"subcommand": "add"')) {
       return {
         outputText: JSON.stringify({
@@ -9579,7 +9583,7 @@ test('/auto natural language proposes deleting a matching job before confirm', a
 
   const originalStartTurn = openai.startTurn.bind(openai);
   openai.startTurn = async (params: any) => {
-    const parserInput = String(params?.inputText ?? '');
+    const parserInput = normalizeCommandSkillInput(params?.inputText);
     if (parserInput.includes('docs/command-skills/auto.md') && parserInput.includes('"subcommand": "natural"')) {
       assert.match(parserInput, /微博热搜前10条/);
       return {

--- a/test/platforms/weixin/cli.test.ts
+++ b/test/platforms/weixin/cli.test.ts
@@ -47,6 +47,23 @@ test('materializeQrArtifact stores data-url qr images on disk', async () => {
   assert.equal(result.sourceUrl, null);
 });
 
+test('materializeQrArtifact renders URL qr content into a real png', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codexbridge-cli-'));
+  const result = await materializeQrArtifact({
+    stateDir: tmpDir,
+    qrcode: 'qr-url-123',
+    qrcodeImageContent: 'https://liteapp.weixin.qq.com/q/?qrcode=abc&bot_type=3',
+  });
+
+  assert.ok(result.filePath);
+  assert.equal(fs.existsSync(result.filePath), true);
+  assert.equal(result.sourceUrl, 'https://liteapp.weixin.qq.com/q/?qrcode=abc&bot_type=3');
+  assert.deepEqual(
+    fs.readFileSync(result.filePath).subarray(0, 8),
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  );
+});
+
 test('parseWeixinServeArgs reads state-dir flag', () => {
   const parsed = parseWeixinServeArgs([
     '--state-dir', '/tmp/codexbridge-state',


### PR DESCRIPTION
## Summary
- render URL-based Weixin login QR content into a local PNG instead of downloading the URL target as if it were an image
- add a Windows job to the CI matrix so the issue-10 fix is validated on `windows-latest`

## Why
Issue #10 reports that `qrcode_img_content` can be an `https://liteapp.weixin.qq.com/q/...` URL. The current CLI flow writes the fetched response body to a `.png` path, which can produce an HTML file masquerading as a PNG. This PR changes the URL branch to locally generate a QR PNG from the URL itself and uses GitHub Actions to validate the change on Windows.

## Validation
- `npm run typecheck`
- `npm test`
- GitHub Actions `CI` on Ubuntu + Windows

Closes #10.