### PR TITLE
feat: add Requesty as an OpenAI-compatible upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL / DEEPSEEK_DEFAULT_MODEL
 MINIMAX_API_KEY / MINIMAX_BASE_URL / MINIMAX_MODEL
 QWEN_API_KEY or DASHSCOPE_API_KEY / QWEN_BASE_URL / QWEN_MODEL
 OPENROUTER_API_KEY / OPENROUTER_BASE_URL / OPENROUTER_MODEL
+REQUESTY_API_KEY / REQUESTY_BASE_URL / REQUESTY_DEFAULT_MODEL
 KIMI_API_KEY / KIMI_BASE_URL / KIMI_MODEL
 GEMINI_API_KEY / GEMINI_BASE_URL / GEMINI_MODEL
 IFLOW_API_KEY / IFLOW_BASE_URL / IFLOW_MODEL
@@ -257,7 +258,7 @@ OpenAI-compatible runtime adapter:
 
 - CodexBridge can expose non-OpenAI providers through a local Responses adapter while Codex app-server still talks to a Responses-shaped endpoint.
 - The adapter now handles `/responses/compact`, Chat Completions conversion, stream error mapping, CLIProxyAPI top-level stream error chunks, stream read failure framing, configured transient upstream retry, usage fallback including Gemini-family `usageMetadata`, provider/model thinking policy, CLIProxyAPI-style payload compatibility (`default`, `default-raw`/`defaultRaw`, `override`, `override-raw`/`overrideRaw`, `filter`, `root`, protocol/model matching), multimodal input capability flags, and model capability metadata.
-- DeepSeek, MiniMax, Qwen, OpenRouter, Kimi, Gemini, and iFlow are loaded as `providerKind: openai-compatible`; they differ by env vars and capability presets only, not separate provider plugin classes.
+- DeepSeek, MiniMax, Qwen, OpenRouter, Requesty, Kimi, Gemini, and iFlow are loaded as `providerKind: openai-compatible`; they differ by env vars and capability presets only, not separate provider plugin classes.
 - The model capability catalog follows the same direction as CLIProxyAPI: model quirks are represented as data (`thinking`, `payload`, tool support, multimodal support, token caps), while the executor stays generic.
 - Current built-in catalog covers the CLIProxyAPI model families used by Codex-style routing: Codex, DeepSeek, MiniMax, Qwen, iFlow, Kimi, OpenRouter, Gemini/AI Studio/Vertex, Claude, and Antigravity. `*_MODEL_CATALOG_PATH` can also point at a CLIProxyAPI `models.json`-shaped catalog object; CodexBridge flattens it and merges model token/thinking metadata into runtime capabilities. Native auth/header systems from CLIProxyAPI are not copied into this adapter; use provider env vars or the custom `CODEX_COMPAT_*` profile for deployment-specific credentials.
 - Auth pools, proxy rotation, and custom provider header management remain deployment-layer concerns and are intentionally separate from the generic OpenAI-compatible adapter.
@@ -290,7 +291,7 @@ CODEX_COMPAT_PROVIDER_ID=custom
 CODEX_COMPAT_API_KEY=...
 CODEX_COMPAT_BASE_URL=https://provider.example/v1
 CODEX_COMPAT_DEFAULT_MODEL=example-model
-CODEX_COMPAT_CAPABILITIES=default # or deepseek/minimax/qwen/kimi/gemini/iflow/openrouter
+CODEX_COMPAT_CAPABILITIES=default # or deepseek/minimax/qwen/kimi/gemini/iflow/openrouter/requesty
 CODEX_COMPAT_REQUEST_RETRY=2
 ```
 
@@ -564,7 +565,7 @@ That file is the stable place to adjust:
 
 - `WEIXIN_ACCOUNT_ID`
 - `CODEX_DEFAULT_PROVIDER_PROFILE_ID`
-- optional OpenAI-compatible provider keys such as `DEEPSEEK_*`, `MINIMAX_*`, `QWEN_*`, `OPENROUTER_*`, or `CODEX_COMPAT_*`
+- optional OpenAI-compatible provider keys such as `DEEPSEEK_*`, `MINIMAX_*`, `QWEN_*`, `OPENROUTER_*`, `REQUESTY_*`, or `CODEX_COMPAT_*`
 - `CODEXBRIDGE_DEBUG_WEIXIN`
 
 ### Windows Scheduled Task

--- a/packages/codex-provider-relay/docs/LIVE_SMOKE_RECIPES.md
+++ b/packages/codex-provider-relay/docs/LIVE_SMOKE_RECIPES.md
@@ -19,6 +19,14 @@ export EMBEDDINGS_API_ENDPOINT=https://openrouter.ai/api/v1/embeddings
 export EMBEDDINGS_MODEL=qwen/qwen3-embedding-8b
 ```
 
+Requesty is an OpenAI-compatible gateway and can be smoke-tested the same way (`provider/model` naming):
+
+```bash
+export REQUESTY_API_KEY=...
+export REQUESTY_BASE_URL=https://router.requesty.ai/v1
+export REQUESTY_DEFAULT_MODEL=openai/gpt-4o-mini
+```
+
 The embedding endpoint/model are defaults only. Any OpenAI-compatible embeddings API can be used.
 
 ## Smoke 1: Mixed Runtime

--- a/packages/codex-provider-relay/docs/RECIPES.md
+++ b/packages/codex-provider-relay/docs/RECIPES.md
@@ -19,6 +19,21 @@ const runtime = new CodexProviderRuntime({
 });
 ```
 
+## Mixed Requesty Runtime
+
+Requesty is an OpenAI-compatible LLM gateway. Wire it exactly like OpenRouter, swapping the base URL, provider label, and API key env var. Models use `provider/model` naming (for example `openai/gpt-4o-mini`).
+
+```ts
+const runtime = new CodexProviderRuntime({
+  apiKey: process.env.REQUESTY_API_KEY!,
+  upstreamBaseUrl: "https://router.requesty.ai/v1",
+  defaultModel: "openai/gpt-4o-mini",
+  providerLabel: "requesty",
+  profileMode: "mixed",
+  toolStrategy: "codex-local-first",
+});
+```
+
 ## Relay-Emulated Hosted Tools
 
 Relay-emulated tools must be declared and registered.
@@ -67,6 +82,16 @@ Use the new prefix for new deployments:
 CODEX_PROVIDER_RELAY_CAPABILITY_PRESET=openrouter
 CODEX_PROVIDER_RELAY_API_KEY=...
 CODEX_PROVIDER_RELAY_MODEL=deepseek/deepseek-chat
+CODEX_PROVIDER_RELAY_TRACE=stderr-json
+codex-provider-server
+```
+
+The same shape works for the `requesty` preset (base `https://router.requesty.ai/v1`):
+
+```bash
+CODEX_PROVIDER_RELAY_CAPABILITY_PRESET=requesty
+CODEX_PROVIDER_RELAY_API_KEY=...
+CODEX_PROVIDER_RELAY_MODEL=openai/gpt-4o-mini
 CODEX_PROVIDER_RELAY_TRACE=stderr-json
 codex-provider-server
 ```

--- a/packages/codex-provider-relay/src/capabilities/capability_presets.ts
+++ b/packages/codex-provider-relay/src/capabilities/capability_presets.ts
@@ -19,6 +19,7 @@ export type OpenAICompatibleCapabilityPresetId =
   | 'minimax'
   | 'qwen'
   | 'openrouter'
+  | 'requesty'
   | 'iflow'
   | 'kimi'
   | 'antigravity'
@@ -150,6 +151,15 @@ const PRESETS: Record<OpenAICompatibleCapabilityPresetId, OpenAICompatibleProvid
     defaultModel: 'openai/gpt-4o-mini',
     ownedBy: 'openrouter',
     categories: ['openrouter'],
+  }),
+  requesty: buildPreset({
+    id: 'requesty',
+    displayName: 'Requesty',
+    apiKeyEnv: 'REQUESTY_API_KEY',
+    baseUrl: 'https://router.requesty.ai/v1',
+    defaultModel: 'openai/gpt-4o-mini',
+    ownedBy: 'requesty',
+    categories: ['requesty'],
   }),
   iflow: buildPreset({
     id: 'iflow',
@@ -297,6 +307,10 @@ export const OPENAI_COMPATIBLE_PROFILE_PRESET_REGISTRATIONS: readonly OpenAIComp
   {
     presetId: 'openrouter',
     envPrefix: 'OPENROUTER',
+  },
+  {
+    presetId: 'requesty',
+    envPrefix: 'REQUESTY',
   },
   {
     presetId: 'kimi',
@@ -798,6 +812,7 @@ function normalizePresetId(id: string | null | undefined): OpenAICompatibleCapab
     case 'minimax':
     case 'qwen':
     case 'openrouter':
+    case 'requesty':
     case 'iflow':
     case 'kimi':
     case 'antigravity':

--- a/packages/codex-provider-relay/src/capabilities/cliproxy_model_catalog.ts
+++ b/packages/codex-provider-relay/src/capabilities/cliproxy_model_catalog.ts
@@ -19,7 +19,8 @@ export type CliproxyModelCategory =
   | 'antigravity'
   | 'minimax-codex'
   | 'deepseek-codex'
-  | 'openrouter';
+  | 'openrouter'
+  | 'requesty';
 
 export interface CliproxyModelCatalogEntry {
   category: CliproxyModelCategory;
@@ -152,6 +153,7 @@ const DIRECT_COMPAT_MODELS: CliproxyModelCatalogEntry[] = [
   model('deepseek-codex', 'deepseek-v4-flash', 'deepseek', 'DeepSeek V4 Flash', null, { maxOutputTokens: 65536 }),
   model('deepseek-codex', 'deepseek-v4-pro', 'deepseek', 'DeepSeek V4 Pro', null, { maxOutputTokens: 65536 }),
   model('openrouter', 'openai/gpt-4o-mini', 'openrouter', 'OpenAI GPT-4o Mini', null, { maxOutputTokens: 16384 }),
+  model('requesty', 'openai/gpt-4o-mini', 'requesty', 'OpenAI GPT-4o Mini', null, { maxOutputTokens: 16384 }),
 ];
 
 export const CLIPROXY_COMPAT_MODEL_CATALOG: CliproxyModelCatalogEntry[] = [

--- a/test/providers/openai_compatible/live_provider_smoke.test.ts
+++ b/test/providers/openai_compatible/live_provider_smoke.test.ts
@@ -28,6 +28,10 @@ const PROVIDERS: LiveProviderSpec[] = [{
   profileId: 'openrouter',
   name: 'OpenRouter',
   apiKeyEnvHint: ['OPENROUTER_API_KEY'],
+}, {
+  profileId: 'requesty',
+  name: 'Requesty',
+  apiKeyEnvHint: ['REQUESTY_API_KEY'],
 }];
 
 for (const provider of PROVIDERS) {


### PR DESCRIPTION
## Add Requesty as a supported OpenAI-compatible upstream

This adds [Requesty](https://requesty.ai) as a first-class OpenAI-compatible upstream in `codex-provider-relay`, mirroring the existing OpenRouter provider as closely as possible. Requesty is an OpenAI-compatible LLM gateway (base URL `https://router.requesty.ai/v1`, `Authorization: Bearer <key>`, `provider/model` naming such as `openai/gpt-4o-mini`), so it slots into the same generic adapter path without any new provider plugin class.

### What changed (mirrors OpenRouter at every wiring site)

- **Capability preset** (`packages/codex-provider-relay/src/capabilities/capability_presets.ts`):
  - Added `'requesty'` to the `OpenAICompatibleCapabilityPresetId` union.
  - Added a `requesty` preset to `PRESETS` (`apiKeyEnv: REQUESTY_API_KEY`, `baseUrl: https://router.requesty.ai/v1`, `defaultModel: openai/gpt-4o-mini`, `ownedBy: requesty`).
  - Added a `{ presetId: 'requesty', envPrefix: 'REQUESTY' }` entry to `OPENAI_COMPATIBLE_PROFILE_PRESET_REGISTRATIONS` so it is loaded from env exactly like the other presets.
  - Added `'requesty'` to the `normalizePresetId` switch.
- **Model catalog** (`packages/codex-provider-relay/src/capabilities/cliproxy_model_catalog.ts`): added `'requesty'` to `CliproxyModelCategory` and a `requesty` / `openai/gpt-4o-mini` catalog entry mirroring the OpenRouter one.
- **README smoke env group** (`README.md`): added `REQUESTY_API_KEY / REQUESTY_BASE_URL / REQUESTY_DEFAULT_MODEL` to the "Supported smoke env names" block, plus the provider listings and the `CODEX_COMPAT_CAPABILITIES` / optional-keys references.
- **Smoke env consumer** (`test/providers/openai_compatible/live_provider_smoke.test.ts`): added a `requesty` entry to the live `PROVIDERS` list so the new env group is actually consumed (the preset registration drives `REQUESTY_*` env loading via `loadCodexProfilesFromEnv`), not docs-only.
- **Recipes** (`packages/codex-provider-relay/docs/RECIPES.md`, `LIVE_SMOKE_RECIPES.md`): added a parallel Requesty `CodexProviderRuntime` recipe (`upstreamBaseUrl: "https://router.requesty.ai/v1"`, `providerLabel: "requesty"`, `apiKey: process.env.REQUESTY_API_KEY`, `defaultModel: "openai/gpt-4o-mini"`), a `requesty` capability-preset server-env example, and a Requesty live-smoke env block. The OpenRouter examples are unchanged.

### Verification

- `tsc -p packages/codex-provider-relay/tsconfig.json --noEmit` — clean (0 errors).
- `tsx --test packages/codex-provider-relay/test/*.test.ts` — 181 pass, 1 skip, 0 fail.
- Root `tsc --noEmit` error count is identical before and after this change (pre-existing, unrelated test-file type issues only); my edited files introduce no new errors.
- Confirmed via the real loader code path that `getOpenAICompatibleProviderPreset('requesty')` resolves to `baseUrl https://router.requesty.ai/v1`, `apiKeyEnv REQUESTY_API_KEY`, `defaultModel openai/gpt-4o-mini`, and that the `REQUESTY` registration is present.
- **Live chat completion** against `https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` returned HTTP 200 with a real completion, confirming the documented base URL and model naming work.

Docs: https://requesty.ai , https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
