### PR TITLE
fix(weixin): 默认关闭进度预览消息

### DIFF
--- a/config/examples/weixin.service.env.example
+++ b/config/examples/weixin.service.env.example
@@ -86,5 +86,9 @@ CODEX_NATIVE_API_ENABLE=1
 # CODEXBRIDGE_INTERNAL_NATIVE_API_AUTH_TOKEN=replace-with-a-long-random-secret
 # CODEXBRIDGE_INTERNAL_NATIVE_API_TASK_CLASSES=intent_classification,normalization,small_verification,side_reasoning
 
+# Weixin delivery behavior. Disabled by default so Weixin receives one final
+# answer instead of streamed preview snippets plus a final commit.
+# CODEXBRIDGE_WEIXIN_PROGRESS_DELIVERY=0
+
 # Debugging
 CODEXBRIDGE_DEBUG_WEIXIN=0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -237,6 +237,7 @@ async function runWeixinServe(args: string[]) {
     automationJobs: runtime.services.automationJobs,
     agentJobs: runtime.services.agentJobs,
     assistantRecords: runtime.services.assistantRecords,
+    progressDeliveryEnabled: parseBooleanEnv(process.env.CODEXBRIDGE_WEIXIN_PROGRESS_DELIVERY, false),
     onError: (async (error: unknown) => {
       process.stderr.write(`[weixin] ${formatError(error)}\n`);
     }) as any,

--- a/src/runtime/weixin_bridge_runtime.ts
+++ b/src/runtime/weixin_bridge_runtime.ts
@@ -145,6 +145,7 @@ interface WeixinBridgeRuntimeOptions {
   previewSoftTargetBytes?: number;
   previewHardLimitBytes?: number;
   previewIntervalMs?: number;
+  progressDeliveryEnabled?: boolean;
   typingKeepaliveMs?: number;
   inboundAttachmentMergeWindowMs?: number;
   automationPollMs?: number;
@@ -174,6 +175,8 @@ export class WeixinBridgeRuntime {
   previewHardLimitBytes: number;
 
   previewIntervalMs: number;
+
+  progressDeliveryEnabled: boolean;
 
   typingKeepaliveMs: number;
 
@@ -219,6 +222,7 @@ export class WeixinBridgeRuntime {
     previewSoftTargetBytes = 2048,
     previewHardLimitBytes = 2048,
     previewIntervalMs = 3000,
+    progressDeliveryEnabled = true,
     typingKeepaliveMs = WeixinBridgeRuntime.DEFAULT_TYPING_KEEPALIVE_MS,
     inboundAttachmentMergeWindowMs = 3000,
     automationPollMs = 30_000,
@@ -234,6 +238,7 @@ export class WeixinBridgeRuntime {
     this.previewSoftTargetBytes = previewSoftTargetBytes;
     this.previewHardLimitBytes = previewHardLimitBytes;
     this.previewIntervalMs = previewIntervalMs;
+    this.progressDeliveryEnabled = progressDeliveryEnabled;
     this.typingKeepaliveMs = typingKeepaliveMs;
     this.inboundAttachmentMergeWindowMs = inboundAttachmentMergeWindowMs;
     this.automationPollMs = automationPollMs;
@@ -534,7 +539,7 @@ export class WeixinBridgeRuntime {
     try {
       const response = await this.bridgeCoordinator.handleInboundEvent(event, {
         onProgress: async (progress) => {
-          if (options.suppressProgressDelivery) {
+          if (options.suppressProgressDelivery || !this.progressDeliveryEnabled) {
             return;
           }
           await this.handleProgressUpdate(event, streamState, progress);

--- a/test/runtime/weixin_bridge_runtime.test.ts
+++ b/test/runtime/weixin_bridge_runtime.test.ts
@@ -37,6 +37,7 @@ interface RuntimeHarnessOptions {
   commitSyncCursor?: (syncCursor: string) => Promise<void> | void;
   previewSoftTargetBytes?: number;
   previewIntervalMs?: number;
+  progressDeliveryEnabled?: boolean;
   typingKeepaliveMs?: number;
   inboundAttachmentMergeWindowMs?: number;
   automationPollMs?: number;
@@ -55,6 +56,7 @@ function makeRuntime({
   commitSyncCursor,
   previewSoftTargetBytes = 1,
   previewIntervalMs = 0,
+  progressDeliveryEnabled = true,
   typingKeepaliveMs = 8000,
   inboundAttachmentMergeWindowMs = 3000,
   automationPollMs = 30_000,
@@ -109,6 +111,7 @@ function makeRuntime({
     assistantRecords,
     previewSoftTargetBytes,
     previewIntervalMs,
+    progressDeliveryEnabled,
     typingKeepaliveMs,
     inboundAttachmentMergeWindowMs,
     automationPollMs,
@@ -1535,6 +1538,38 @@ test('WeixinBridgeRuntime merges commentary and final-answer progress into the p
   assert.deepEqual(sent, [
     { externalScopeId: 'wxid_1', content: '我先检查一下上下文。' },
     { externalScopeId: 'wxid_1', content: '最终答案第一段。\n\n最终答案第二段。' },
+  ]);
+});
+
+test('WeixinBridgeRuntime can disable Weixin progress preview delivery and send only the final response', async () => {
+  const sent: Array<{ externalScopeId: string; content: string }> = [];
+  const runtime = makeRuntime({
+    sendText: async ({ externalScopeId, content }) => {
+      sent.push({ externalScopeId, content });
+    },
+    progressDeliveryEnabled: false,
+    previewSoftTargetBytes: 1024,
+    coordinator: {
+      async handleInboundEvent(_event: any, options: any = {}) {
+        await options.onProgress?.({
+          text: '第一段预览。',
+          delta: '第一段预览。',
+          outputKind: 'commentary',
+        });
+        await options.onProgress?.({
+          text: '最终答案。',
+          delta: '最终答案。',
+          outputKind: 'final_answer',
+        });
+        return completeResponse('最终答案。');
+      },
+    },
+  });
+
+  await runtime.runOnce();
+
+  assert.deepEqual(sent, [
+    { externalScopeId: 'wxid_1', content: '最终答案。' },
   ]);
 });
 


### PR DESCRIPTION
## 背景

微信桥在流式回复期间会发送多段进度预览，随后再发送最终回复。
这会造成消息刷屏，并增加微信侧发送频率限制（`ret:-2`）的触发概率。

## 变更

- 将 `CODEXBRIDGE_WEIXIN_PROGRESS_DELIVERY` 默认值调整为 `false`
- 默认仅发送最终完整回复
- 保留环境变量开关；需要逐步预览时可显式设置为 `1`
- 补充配置示例与运行时测试

## 影响

- 默认微信交付更稳定、消息更简洁
- 不影响最终回复、审批通知、输入状态
- 不改变已有的显式开启预览行为